### PR TITLE
Change `dt/android/color`'s output from RGBA to ARGB

### DIFF
--- a/build.js
+++ b/build.js
@@ -68,7 +68,7 @@ StyleDictionary.registerTransform({
   },
   transformer: (token, options) => {
     const hex8 = Color(token.value).toHex8();
-    return `Color(0x${hex8})`;
+    return `Color(0x${hex8.slice(6) + hex8.slice(0, 6)})`;
   }
 });
 


### PR DESCRIPTION
Compose expects colors in the ARGB format rather than RGBA, so the color needs to be sliced differently. 

Based on style-dictionary's [own `color/composeColor` transform here](https://github.com/amzn/style-dictionary/blob/442a5eccf5eb18edae7877ff96712d189316a6dd/lib/common/transforms.js#L427).

Alternatively, if possible we could just use `color/composeColor` itself rather than redefining it as `dt/android/color`.