### PR TITLE
fix: updated iOS source destination

### DIFF
--- a/build-ios.js
+++ b/build-ios.js
@@ -8,8 +8,8 @@ if (!fs.existsSync('dist_ios/Sources')) {
 }
 
 THEMES.forEach(theme => {
-  fs.copyFile(`dist/ios/tokens-${theme}.swift`, `dist_ios/Sources/tokens-${theme}.swift`, (err) => {
+  fs.copyFile(`dist/ios/tokens-${theme}.swift`, `dist_ios/Sources/DialtoneTokens/tokens-${theme}.swift`, (err) => {
     if (err) throw err;
-    console.log(`dialtone.swift was copied to dist_ios/Sources/tokens-${theme}.swift`);
+    console.log(`dialtone.swift was copied to dist_ios/Sources/DialtoneTokens/tokens-${theme}.swift`);
   });
 });

--- a/build-ios.js
+++ b/build-ios.js
@@ -3,8 +3,8 @@ const fs = require('fs');
 
 const THEMES = require('./build').THEMES;
 
-if (!fs.existsSync('dist_ios/Sources')) {
-  fs.mkdirSync('dist_ios/Sources')
+if (!fs.existsSync('dist_ios/Sources/DialtoneTokens')) {
+  fs.mkdirSync( 'dist_ios/Sources/DialtoneTokens', { recursive: true })
 }
 
 THEMES.forEach(theme => {


### PR DESCRIPTION
Updated the source folder to be `Sources/DialtoneTokens`

Fixed the source with this PR in the Swift repo:
https://github.com/dialpad/dialtone-tokens-swift/pull/1